### PR TITLE
Self enclosing element will not return `undefined`.

### DIFF
--- a/excelParser.js
+++ b/excelParser.js
@@ -79,11 +79,13 @@ function extractData(files) {
 	});
 
 	var cells = sheet.find('//a:sheetData//a:row//a:c', ns),
-		na = {value: function() { return ''; }};
+		na = { value: function() { return ''; },
+           text:  function() { return ''; } };
+
 	_.each(cells, function(_cell) {
 		var r = _cell.attr('r').value(),
 			type = (_cell.attr('t') || na).value(),
-			value = _cell.get('a:v', ns).text(),
+			value = ( _cell.get('a:v', ns) || na ).text(),
 			cell = new Cell(r);
 
 		if (type == 's') value = strings.get('//a:si[' + (parseInt(value) + 1) + ']//a:t', ns).text();


### PR DESCRIPTION
```
TypeError: Cannot call method 'text' of undefined
    at /path/to/node_modules/excel/excelParser.js:86:33
```

It occurs when `_cell` instance which has an element like  `<c r="B1" s="2"/>` tries to perform `.get`

the `na` object should have `value` method as well then when it returns `undefined` it should simply return empty string.
