### PR TITLE
Take a Stream object instead of a file path as the input argument

### DIFF
--- a/excelParser.js
+++ b/excelParser.js
@@ -16,8 +16,12 @@ function extractFiles(path) {
 			deferred: defer()
 		}
 	};
+	
+	var srcStream = path instanceof require('stream') ?
+		path :
+		require('fs').createReadStream(path);
 
-	require('fs').createReadStream(path)
+	srcStream
 		.pipe(unzip.Parse())
 		.on('error', function(err) {
 			deferred.reject(err);


### PR DESCRIPTION
If a Stream object was passed instead of a file path, then use it directly for the pipe.

This allow using the module together with other sources of data (e.g., files stored in a db, as in my case).

Thanks for your nice module!
