### PR TITLE
Support for multiple t nodes in strings

### DIFF
--- a/excelParser.js
+++ b/excelParser.js
@@ -138,7 +138,7 @@ function extractData(files) {
 		var value = cell.value;
 
 		if (cell.type == 's') {
-			values = strings.find('//a:si[' + (parseInt(value) + 1) + ']//a:t', ns)
+			values = strings.find('//a:si[' + (parseInt(value) + 1) + ']//a:t[not(ancestor::a:rPh)]', ns)
 			value = "";
 			for (var i = 0; i < values.length; i++) {
 				value += values[i].text();


### PR DESCRIPTION
Sometimes formatting (specially with japanese characters) separates text in multiple t nodes. Just "get" will result in only one node. Which works in many cases but breaks in some.
