### PR TITLE
Fixed issue #40

### DIFF
--- a/excelParser.js
+++ b/excelParser.js
@@ -145,7 +145,9 @@ function extractData(files) {
 			}
 		}
 		
-		data[cell.row - d[0].row][cell.column - d[0].column] = value;
+		if (data[cell.row - d[0].row]) {
+			data[cell.row - d[0].row][cell.column - d[0].column] = value;
+		}
 	});
 
 	return data;


### PR DESCRIPTION
Prevents an error from being thrown if the spreadsheet contains a header or title above the table.

More details in issue #40.