### PR TITLE
install failed: libxmljs missing it's build file. #60

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1597,16 +1597,6 @@
         "is-buffer": "1.1.6"
       }
     },
-    "libxmljs": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/libxmljs/-/libxmljs-0.19.0.tgz",
-      "integrity": "sha1-NnPrF8dMuv/e+fM8uD3dgqJQVbc=",
-      "requires": {
-        "bindings": "1.2.1",
-        "nan": "2.5.1",
-        "node-pre-gyp": "0.6.39"
-      }
-    },
     "listenercount": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1598,8 +1598,8 @@
       }
     },
     "libxmljs": {
-      "version": "0.18.7",
-      "resolved": "https://registry.npmjs.org/libxmljs/-/libxmljs-0.18.7.tgz",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/libxmljs/-/libxmljs-0.19.0.tgz",
       "integrity": "sha1-NnPrF8dMuv/e+fM8uD3dgqJQVbc=",
       "requires": {
         "bindings": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "prepublish": "npm run test"
   },
   "dependencies": {
-    "libxmljs": "^0.18.0",
     "unzipper": "^0.8.11",
     "xmldom": "^0.1.27",
     "xpath": "0.0.27"


### PR DESCRIPTION
libxmljs is causing an error when doing an  npm install... It looks like the project does not use libxmljs anymore. I took it out and tested it. Seems to be working for me.